### PR TITLE
Database connectivity optimizations - Hikari

### DIFF
--- a/config/application.properties.model
+++ b/config/application.properties.model
@@ -3,6 +3,11 @@ spring.datasource.url=jdbc:postgresql://localhost:5432/lrharvester
 spring.datasource.username=lrharvester
 spring.datasource.password=lrharvester
 
+# minimum number of idle connections maintained by HikariCP in a connection pool
+spring.datasource.hikari.minimum-idle=10
+# maximum pool size
+spring.datasource.hikari.maximum-pool-size=50
+
 #rest port
 server.port=8090
 # UNCOMMENT if you use a Apache proxy pass and need Spring to handle request types


### PR DESCRIPTION
I've added this default settings to the default properties (it can be copied to your application.properties ) to help optimize the postgresql connections, enabling you to use more than the default created connections. In this case, we will have 10 idle connections and the maximum of 50. It will depend mostly on the server capacity.

```
# minimum number of idle connections maintained by HikariCP in a connection pool
spring.datasource.hikari.minimum-idle=10
# maximum pool size
spring.datasource.hikari.maximum-pool-size=50
```