### PR TITLE
Adding missing configuration and xsl mapping

### DIFF
--- a/config/beans/actions.rcaap.xml
+++ b/config/beans/actions.rcaap.xml
@@ -41,7 +41,7 @@
 	
 	<import resource="index.rcaap.actions.xml"/>   <!-- RCAAP ONLY  -->
 	
-	<import resource="xoai.actions.xml" />
+	<import resource="xoai.rcaap.actions.xml" />
 	<import resource="fulltext.actions.xml" />
 	<import resource="historic.actions.xml" />
 	<import resource="network.actions.xml" />
@@ -72,8 +72,8 @@
   				<ref bean="rcaapDeleteAction"/>
   				
 				<!-- XOAI Actions -->
-				<ref bean="xoaiIndexingNetworkAction" />
-				<ref bean="xoaiDeleteAction" />
+				<ref bean="rcaapXoaiIndexingNetworkAction" />
+				<ref bean="rcaapXoaiDeleteAction" />
 
 				<!-- Historic Actions -->
 				<ref bean="historicIndexingNetworkAction" />

--- a/config/beans/xoai.rcaap.actions.xml
+++ b/config/beans/xoai.rcaap.actions.xml
@@ -38,14 +38,14 @@
 
 
 	<!-- Actions -->
-	<bean id="xoaiIndexingNetworkAction" class="org.lareferencia.backend.taskmanager.NetworkAction">
+	<bean id="rcaapXoaiIndexingNetworkAction" class="org.lareferencia.backend.taskmanager.NetworkAction">
 		<property name="name" value="XOAI_INDEXING_ACTION" />
 		<property name="description" value="Index OAI-PMH"></property>
 		<property name="incremental" value="true" />
 		<property name="runOnSchedule" value="true" />
 		<property name="workers">
 			<list>
-				<value>xoaiIndexerWorker</value>
+				<value>xoaiIndexerWorker2</value>
 			</list>
 		</property>
 		<property name="properties">
@@ -59,18 +59,18 @@
 	</bean>
 
 
-	<bean id="xoaiDeleteAction" class="org.lareferencia.backend.taskmanager.NetworkAction">
+	<bean id="rcaapXoaiDeleteAction" class="org.lareferencia.backend.taskmanager.NetworkAction">
 		<property name="name" value="XOAI_DELETE_ACTION" />
 		<property name="description" value="UnIndex OAI-PMH"></property>
 		<property name="workers">
 			<list>
-				<value>xoaiDeleteWorker</value>
+				<value>xoaiDeleteWorker2</value>
 			</list>
 		</property>
 	</bean>
 
 	<!-- Workers -->
-	<bean id="xoaiIndexerWorker" class="org.lareferencia.backend.workers.indexer.IndexerWorker"
+	<bean id="xoaiIndexerWorker2" class="org.lareferencia.backend.workers.indexer.IndexerWorker"
 		scope="prototype">
 		<constructor-arg>
 			<value>${xoai.solr.url}</value>
@@ -89,12 +89,12 @@
 
 		<property name="indexDeletedRecords" value="true" />
 		<!-- index network attributes in OAI (dafault action is false) -->
-		<property name="indexNetworkAttributes" value="false" />
+		<property name="indexNetworkAttributes" value="true" />
 		
 	</bean>
 
 
-	<bean id="xoaiDeleteWorker" class="org.lareferencia.backend.workers.indexer.IndexerWorker"
+	<bean id="xoaiDeleteWorker2" class="org.lareferencia.backend.workers.indexer.IndexerWorker"
 		scope="prototype">
 		<constructor-arg>
 			<value>${xoai.solr.url}</value>

--- a/config/mdfcrosswalks/xoai-openaire2provider.xsl
+++ b/config/mdfcrosswalks/xoai-openaire2provider.xsl
@@ -41,6 +41,12 @@
 	<xsl:param name="deleted" />
 	<xsl:param name="record_id" />
 	
+	<!-- Params from Networks -->
+	<!-- They have the prefix: "attr_"  -->
+	<xsl:param name="attr_country"/>
+	<xsl:param name="attr_tags"/>
+	<!-- / -->
+	
 	<xsl:strip-space elements="*"/>
 	
 	<xsl:template match="/">
@@ -61,6 +67,21 @@
             <field name="item.public">true</field>    
             
             <field name="item.collections"><xsl:value-of select="$networkAcronym"/></field>
+
+			<!-- create a set for each country -->
+			<xsl:if test="$attr_country and ($attr_country != '')">
+				<field name="item.collections">
+					<xsl:value-of select="$attr_country"/>
+				</field>
+			</xsl:if>
+			<!-- create a set for each tag -->
+			<xsl:if test="$attr_tags">
+				<xsl:for-each select="$attr_tags">
+					<field name="item.collections">
+						<xsl:value-of select="."/>
+					</field>
+				</xsl:for-each>
+			</xsl:if>
             
             <field name="item.communities">com_<xsl:value-of select="$institutionAcronym"/></field>
 			

--- a/config/mdfcrosswalks/xoai2provider.xsl
+++ b/config/mdfcrosswalks/xoai2provider.xsl
@@ -41,6 +41,12 @@
 	<xsl:param name="deleted" />
 	<xsl:param name="record_id" />
 	
+	<!-- Params from Networks -->
+	<!-- They have the prefix: "attr_"  -->
+	<xsl:param name="attr_country"/>
+	<xsl:param name="attr_tags"/>
+	<!-- / -->
+	
 	<xsl:strip-space elements="*"/>
 	
 	<xsl:template match="/">
@@ -72,6 +78,21 @@
             <field name="item.public">true</field>    
             
             <field name="item.collections"><xsl:value-of select="$networkAcronym"/></field>
+
+			<!-- create a set for each country -->
+			<xsl:if test="$attr_country and ($attr_country != '')">
+				<field name="item.collections">
+					<xsl:value-of select="$attr_country"/>
+				</field>
+			</xsl:if>
+			<!-- create a set for each tag -->
+			<xsl:if test="$attr_tags">
+				<xsl:for-each select="$attr_tags">
+					<field name="item.collections">
+						<xsl:value-of select="."/>
+					</field>
+				</xsl:for-each>
+			</xsl:if>
             
             <field name="item.communities">com_<xsl:value-of select="$institutionAcronym"/></field>
 			


### PR DESCRIPTION
We were missing network indexing configuration. So I've just create a new specific RCAAP configuration and add a default:
`<property name="indexNetworkAttributes" value="false" />` so we don't forget.

At the transformation side (provider), I have 2 default transformations.