### PR TITLE
Rename network indexer

### DIFF
--- a/config/beans/network.actions.xml
+++ b/config/beans/network.actions.xml
@@ -120,12 +120,12 @@
 		<property name="executeIndexing" value="false" />
 	</bean>    
     
-	<bean id="networkIndexWorker" class="org.lareferencia.contrib.rcaap.backend.workers.NetworkIndexWorker"
+	<bean id="networkIndexWorker" class="org.lareferencia.contrib.rcaap.backend.workers.NetworkIndexLegacyWorker"
 		scope="prototype">
 		<property name="executeDeletion" value="false" />
 	</bean>
 
-	<bean id="networkUnindexWorker" class="org.lareferencia.contrib.rcaap.backend.workers.NetworkIndexWorker"
+	<bean id="networkUnindexWorker" class="org.lareferencia.contrib.rcaap.backend.workers.NetworkIndexLegacyWorker"
 		scope="prototype">
 		<property name="executeDeletion" value="true" />
 	</bean>


### PR DESCRIPTION
Network indexer it will be refactored. For now, just renaming it, leaving it as is.

FROM:
org.lareferencia.contrib.rcaap.backend.workers.NetworkIndexWorker
TO
org.lareferencia.contrib.rcaap.backend.workers.NetworkIndexLegacyWorker